### PR TITLE
再生リストのタイトルと概要の修正

### DIFF
--- a/go/src/MyPIPE/Test/mock/repository/mock_playListRepository.go
+++ b/go/src/MyPIPE/Test/mock/repository/mock_playListRepository.go
@@ -78,6 +78,21 @@ func (mr *MockPlayListRepositoryMockRecorder) FindByUserID(playListUserID interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByUserID", reflect.TypeOf((*MockPlayListRepository)(nil).FindByUserID), playListUserID)
 }
 
+// FindByIDAndUserID mocks base method
+func (m *MockPlayListRepository) FindByIDAndUserID(playListID model.PlayListID, userId model.UserID) (*model.PlayList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindByIDAndUserID", playListID, userId)
+	ret0, _ := ret[0].(*model.PlayList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindByIDAndUserID indicates an expected call of FindByIDAndUserID
+func (mr *MockPlayListRepositoryMockRecorder) FindByIDAndUserID(playListID, userId interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByIDAndUserID", reflect.TypeOf((*MockPlayListRepository)(nil).FindByIDAndUserID), playListID, userId)
+}
+
 // FindByUserIDAndName mocks base method
 func (m *MockPlayListRepository) FindByUserIDAndName(playListUserID model.UserID, playListName model.PlayListName) ([]model.PlayList, error) {
 	m.ctrl.T.Helper()

--- a/go/src/MyPIPE/domain/model/PlayList.go
+++ b/go/src/MyPIPE/domain/model/PlayList.go
@@ -67,3 +67,13 @@ func (p *PlayList) AddItem(movieId MovieID) error {
 	p.PlayListMovies = append(p.PlayListMovies, movieId)
 	return nil
 }
+
+func (p *PlayList) ChangeName(playListName PlayListName) error {
+	p.Name = playListName
+	return nil
+}
+
+func (p *PlayList) ChangeDescription(playListDescription PlayListDescription) error {
+	p.Description = playListDescription
+	return nil
+}

--- a/go/src/MyPIPE/domain/repository/PlayListRepository.go
+++ b/go/src/MyPIPE/domain/repository/PlayListRepository.go
@@ -6,6 +6,7 @@ type PlayListRepository interface {
 	FindByID(playListID model.PlayListID) (*model.PlayList, error)
 	FindByName(playListName model.PlayListName) ([]model.PlayList, error)
 	FindByUserID(playListUserID model.UserID) ([]model.PlayList, error)
+	FindByIDAndUserID(playListID model.PlayListID, userId model.UserID) (*model.PlayList, error)
 	FindByUserIDAndName(playListUserID model.UserID, playListName model.PlayListName) ([]model.PlayList, error)
 	Save(playList *model.PlayList) error
 	Remove(userId model.UserID, playListId model.PlayListID) error

--- a/go/src/MyPIPE/handler/UpdatePlayList.go
+++ b/go/src/MyPIPE/handler/UpdatePlayList.go
@@ -1,0 +1,80 @@
+package handler
+
+import (
+	"MyPIPE/domain/model"
+	"MyPIPE/usecase"
+	"encoding/json"
+	jwt "github.com/appleboy/gin-jwt/v2"
+	"github.com/gin-gonic/gin"
+	"net/http"
+)
+
+type UpdatePlayList struct {
+	UpdatePlayListUsecase usecase.IUpdatePlayList
+}
+
+func NewUpdatePlayListHandler(updatePlayListUsecase usecase.IUpdatePlayList) *UpdatePlayList {
+	return &UpdatePlayList{
+		UpdatePlayListUsecase: updatePlayListUsecase,
+	}
+}
+
+func (u UpdatePlayList) Update(c *gin.Context) {
+	var updatePlayListJson UpdatePlayListJson
+	c.Bind(&updatePlayListJson)
+	iuserId := uint64(jwt.ExtractClaims(c)["id"].(float64))
+
+	validationErrors := make(map[string]string)
+
+	userId, userIdErr := model.NewUserID(iuserId)
+	if userIdErr != nil {
+		validationErrors["user_id"] = userIdErr.Error()
+	}
+
+	playListId, playListIdErr := model.NewPlayListID(updatePlayListJson.PlayListID)
+	if playListIdErr != nil {
+		validationErrors["play_list_id"] = playListIdErr.Error()
+	}
+
+	playListName, playListNameErr := model.NewPlayListName(updatePlayListJson.PlayListName)
+	if playListNameErr != nil {
+		validationErrors["play_list_name"] = playListNameErr.Error()
+	}
+
+	playListDescription, playListDescriptionErr := model.NewPlayListDescription(updatePlayListJson.PlayListDescription)
+	if playListDescriptionErr != nil {
+		validationErrors["play_list_description"] = playListDescriptionErr.Error()
+	}
+
+	if len(validationErrors) != 0 {
+		validationErrors, _ := json.Marshal(validationErrors)
+		c.JSON(http.StatusBadRequest, gin.H{
+			"result":   "Validation Error.",
+			"messages": string(validationErrors),
+		})
+		c.Abort()
+		return
+	}
+
+	updatePlayListDTO := usecase.NewUpdatePlayListDTO(userId, playListId, playListName, playListDescription)
+	usecaseError := u.UpdatePlayListUsecase.Update(updatePlayListDTO)
+
+	if usecaseError != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"result":   "Update PlayList Failed.",
+			"messages": usecaseError.Error(),
+		})
+		c.Abort()
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "Updated!",
+	})
+}
+
+type UpdatePlayListJson struct {
+	PlayListID          uint64 `json:"play_list_id"`
+	PlayListName        string `json:"play_list_name"`
+	PlayListDescription string `json:"play_list_description"`
+}

--- a/go/src/MyPIPE/infra/PlayListRepository.go
+++ b/go/src/MyPIPE/infra/PlayListRepository.go
@@ -36,6 +36,21 @@ func (p PlayListPersistence) FindByUserID(playListUserID model.UserID) ([]model.
 	panic("implement me")
 }
 
+func (p PlayListPersistence) FindByIDAndUserID(playListID model.PlayListID, userId model.UserID) (*model.PlayList, error) {
+	db := ConnectGorm()
+	defer db.Close()
+	var playList model.PlayList
+	var count int
+	resultFindPlayList := db.Where("id = ? and user_id = ?", playListID, userId).Take(&playList).Count(&count)
+	if resultFindPlayList.Error != nil {
+		return nil, resultFindPlayList.Error
+	}
+	if count == 0 {
+		return nil, nil
+	}
+	return &playList, nil
+}
+
 func (p PlayListPersistence) FindByUserIDAndName(playListUserID model.UserID, playListName model.PlayListName) ([]model.PlayList, error) {
 	db := ConnectGorm()
 	defer db.Close()

--- a/go/src/MyPIPE/main.go
+++ b/go/src/MyPIPE/main.go
@@ -72,7 +72,7 @@ func main() {
 	router := gin.Default()
 
 	router.Use(cors.New(cors.Config{
-		AllowOrigins:     []string{"http://localhost:3000"},
+		AllowOrigins:     []string{"*"},
 		AllowMethods:     []string{"POST", "PUT", "PATCH", "DELETE"},
 		AllowHeaders:     []string{"Origin", "Access-Control-Allow-Origin", "Content-type", "Authorization"},
 		ExposeHeaders:    []string{"Content-Length"},
@@ -159,6 +159,19 @@ func main() {
 		createPlayListHandler := handler.NewCreatePlayList(userRepository, playListRepository, createPlayListUsecase)
 		auth.POST("/play-lists", createPlayListHandler.CreatePlayList)
 
+		indexPlayListsInMyPageQueryService := queryService_infra.NewIndexPlayListsInMyPage()
+		indexPlayListsInMyPageUsecase := usecase.NewIndexPlayListsInMyPage(indexPlayListsInMyPageQueryService)
+		indexPlayListsInMyPageHandler := handler.NewIndexPlayListsInMyPage(indexPlayListsInMyPageQueryService, indexPlayListsInMyPageUsecase)
+		auth.GET("/play-lists", indexPlayListsInMyPageHandler.IndexPlayListsInMyPage)
+
+		updatePlayListUsecase := usecase.NewUpdatePlayList(playListRepository)
+		updatePlayListHandler := handler.NewUpdatePlayListHandler(updatePlayListUsecase)
+		auth.PUT("/play-lists", updatePlayListHandler.Update)
+
+		deletePlayListUsecase := usecase.NewDeletePlayList(playListRepository)
+		deletePlayListHandler := handler.NewDeletePlayList(playListRepository, deletePlayListUsecase)
+		auth.DELETE("/play-lists", deletePlayListHandler.DeletePlayList)
+
 		playListMovieFactory := factory.NewPlayListMovieFactory()
 		addPlayListItemUsecase := usecase.NewAddPlayListItem(playListRepository, playListMovieRepository, playListMovieFactory)
 		deletePlayListMovieUsecase := usecase.NewDeletePlayListMovie(playListRepository, playListMovieRepository)
@@ -172,11 +185,6 @@ func main() {
 
 		auth.POST("/follows", handler.FollowUser)
 
-		indexPlayListsInMyPageQueryService := queryService_infra.NewIndexPlayListsInMyPage()
-		indexPlayListsInMyPageUsecase := usecase.NewIndexPlayListsInMyPage(indexPlayListsInMyPageQueryService)
-		indexPlayListsInMyPageHandler := handler.NewIndexPlayListsInMyPage(indexPlayListsInMyPageQueryService, indexPlayListsInMyPageUsecase)
-		auth.GET("/play-lists", indexPlayListsInMyPageHandler.IndexPlayListsInMyPage)
-
 		indexPlaylistMoviesQueryService := queryService_infra.NewIndexPlayListMovieInMyPage()
 		indexPlaylistMoviesUsecase := usecase.NewIndexPlayListItemInMyPage(indexPlaylistMoviesQueryService)
 		indexPlayListMoviesHandler := handler.NewIndexPlaylistMovies(indexPlaylistMoviesQueryService, indexPlaylistMoviesUsecase)
@@ -186,10 +194,6 @@ func main() {
 		indexPlayListInMovieListPageUsecase := usecase.NewIndexPlayListInMovieListPage(indexPlayListInMovieListPageQueryService)
 		indexPlayListInMovieListPageHandler := handler.NewIndexPlayListInMovieListPage(indexPlayListInMovieListPageQueryService, indexPlayListInMovieListPageUsecase)
 		auth.GET("play-lists/:movie_id", indexPlayListInMovieListPageHandler.IndexPlayListInMovieListPage)
-
-		deletePlayListUsecase := usecase.NewDeletePlayList(playListRepository)
-		deletePlayListHandler := handler.NewDeletePlayList(playListRepository, deletePlayListUsecase)
-		auth.DELETE("/play-lists", deletePlayListHandler.DeletePlayList)
 	}
 
 	router.GET("/health", func(c *gin.Context) {

--- a/go/src/MyPIPE/usecase/UpdatePlayList.go
+++ b/go/src/MyPIPE/usecase/UpdatePlayList.go
@@ -1,0 +1,62 @@
+package usecase
+
+import (
+	"MyPIPE/domain/model"
+	"MyPIPE/domain/repository"
+	"errors"
+)
+
+type IUpdatePlayList interface {
+	Update(updatePlayListDTO *UpdatePlayListDTO) error
+}
+
+type UpdatePlayList struct {
+	PlayListRepository repository.PlayListRepository
+}
+
+func NewUpdatePlayList(playListRepository repository.PlayListRepository) *UpdatePlayList {
+	return &UpdatePlayList{PlayListRepository: playListRepository}
+}
+
+func (u UpdatePlayList) Update(updatePlayListDTO *UpdatePlayListDTO) error {
+	playList, playListFindErr := u.PlayListRepository.FindByIDAndUserID(updatePlayListDTO.PlayListID, updatePlayListDTO.UserID)
+	if playListFindErr != nil {
+		return playListFindErr
+	}
+	if playList == nil {
+		return errors.New("No Such PlayList.")
+	}
+
+	changePlayListNameErr := playList.ChangeName(updatePlayListDTO.PlayListName)
+	if changePlayListNameErr != nil {
+		return changePlayListNameErr
+	}
+
+	changePlayListDescriptionErr := playList.ChangeDescription(updatePlayListDTO.PlayListDescription)
+	if changePlayListDescriptionErr != nil {
+		return changePlayListDescriptionErr
+	}
+
+	savePlayListErr := u.PlayListRepository.Save(playList)
+	if savePlayListErr != nil {
+		return savePlayListErr
+	}
+
+	return nil
+}
+
+type UpdatePlayListDTO struct {
+	UserID              model.UserID
+	PlayListID          model.PlayListID
+	PlayListName        model.PlayListName
+	PlayListDescription model.PlayListDescription
+}
+
+func NewUpdatePlayListDTO(userId model.UserID, playListId model.PlayListID, playListName model.PlayListName, playListDescription model.PlayListDescription) *UpdatePlayListDTO {
+	return &UpdatePlayListDTO{
+		UserID:              userId,
+		PlayListID:          playListId,
+		PlayListName:        playListName,
+		PlayListDescription: playListDescription,
+	}
+}


### PR DESCRIPTION
・再生リストのタイトルと概要の修正用メソッドを実装
go/src/MyPIPE/domain/model/PlayList.go 

・再生リスト修正APIのハンドラー実装
 go/src/MyPIPE/handler/UpdatePlayList.go

・再生リスト修正APIのユースケース実装
go/src/MyPIPE/usecase/UpdatePlayList.go 

・PlayListRepositoryにメソッド追加
go/src/MyPIPE/infra/PlayListRepository.go
go/src/MyPIPE/domain/repository/PlayListRepository.go