### PR TITLE
再生リストのサムネイル設定

### DIFF
--- a/go/src/MyPIPE/Migrations/000025_add_thumbnail_movie_id_column_to_play_lists_table.down.sql
+++ b/go/src/MyPIPE/Migrations/000025_add_thumbnail_movie_id_column_to_play_lists_table.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE play_lists DROP COLUMN thumbnail_movie_id;

--- a/go/src/MyPIPE/Migrations/000025_add_thumbnail_movie_id_column_to_play_lists_table.up.sql
+++ b/go/src/MyPIPE/Migrations/000025_add_thumbnail_movie_id_column_to_play_lists_table.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE play_lists ADD COLUMN thumbnail_movie_id BIGINT UNSIGNED NULL AFTER user_id;

--- a/go/src/MyPIPE/domain/model/PlayList.go
+++ b/go/src/MyPIPE/domain/model/PlayList.go
@@ -37,13 +37,14 @@ func NewPlayListDescription(playListDescription string) (PlayListDescription, er
 }
 
 type PlayList struct {
-	ID             PlayListID   `json:"id" gorm:"primaryKey"`
-	UserID         UserID       `gorm:"column:user_id"`
-	Name           PlayListName `gorm:"column:name"`
-	Description    PlayListDescription
-	PlayListMovies []MovieID `gorm:"-"`
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
+	ID               PlayListID   `json:"id" gorm:"primaryKey"`
+	UserID           UserID       `gorm:"column:user_id"`
+	Name             PlayListName `gorm:"column:name"`
+	Description      PlayListDescription
+	PlayListMovies   []MovieID `gorm:"-"`
+	ThumbnailMovieID MovieID
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
 }
 
 func NewPlayList(userId UserID, name PlayListName, description PlayListDescription) *PlayList {
@@ -75,5 +76,10 @@ func (p *PlayList) ChangeName(playListName PlayListName) error {
 
 func (p *PlayList) ChangeDescription(playListDescription PlayListDescription) error {
 	p.Description = playListDescription
+	return nil
+}
+
+func (p *PlayList) ChangeThumbnailMovie(thumbnailMovieId MovieID) error {
+	p.ThumbnailMovieID = thumbnailMovieId
 	return nil
 }

--- a/go/src/MyPIPE/handler/UpdatePlayList.go
+++ b/go/src/MyPIPE/handler/UpdatePlayList.go
@@ -46,6 +46,11 @@ func (u UpdatePlayList) Update(c *gin.Context) {
 		validationErrors["play_list_description"] = playListDescriptionErr.Error()
 	}
 
+	thumbnailMovieId, thumbnailMovieIdErr := model.NewMovieID(updatePlayListJson.PlayListThumbnailMovieID)
+	if thumbnailMovieIdErr != nil {
+		validationErrors["thumbnail_movie_id"] = thumbnailMovieIdErr.Error()
+	}
+
 	if len(validationErrors) != 0 {
 		validationErrors, _ := json.Marshal(validationErrors)
 		c.JSON(http.StatusBadRequest, gin.H{
@@ -56,7 +61,7 @@ func (u UpdatePlayList) Update(c *gin.Context) {
 		return
 	}
 
-	updatePlayListDTO := usecase.NewUpdatePlayListDTO(userId, playListId, playListName, playListDescription)
+	updatePlayListDTO := usecase.NewUpdatePlayListDTO(userId, playListId, playListName, playListDescription, thumbnailMovieId)
 	usecaseError := u.UpdatePlayListUsecase.Update(updatePlayListDTO)
 
 	if usecaseError != nil {
@@ -74,7 +79,8 @@ func (u UpdatePlayList) Update(c *gin.Context) {
 }
 
 type UpdatePlayListJson struct {
-	PlayListID          uint64 `json:"play_list_id"`
-	PlayListName        string `json:"play_list_name"`
-	PlayListDescription string `json:"play_list_description"`
+	PlayListID               uint64 `json:"play_list_id"`
+	PlayListName             string `json:"play_list_name"`
+	PlayListDescription      string `json:"play_list_description"`
+	PlayListThumbnailMovieID uint64 `json:"play_list_thumbnail_movie_id"`
 }

--- a/go/src/MyPIPE/infra/MovieRepository.go
+++ b/go/src/MyPIPE/infra/MovieRepository.go
@@ -26,9 +26,13 @@ func (m *MoviePersistence) FindById(id model.MovieID) (*model.Movie, error) {
 	db := ConnectGorm()
 	defer db.Close()
 	var movies model.Movie
-	result := db.First(&movies, uint64(id))
+	var count int
+	result := db.First(&movies, uint64(id)).Count(&count)
 	if result.Error != nil {
 		return nil, result.Error
+	}
+	if count == 0 {
+		return nil, nil
 	}
 	return &movies, nil
 }

--- a/go/src/MyPIPE/main.go
+++ b/go/src/MyPIPE/main.go
@@ -164,7 +164,7 @@ func main() {
 		indexPlayListsInMyPageHandler := handler.NewIndexPlayListsInMyPage(indexPlayListsInMyPageQueryService, indexPlayListsInMyPageUsecase)
 		auth.GET("/play-lists", indexPlayListsInMyPageHandler.IndexPlayListsInMyPage)
 
-		updatePlayListUsecase := usecase.NewUpdatePlayList(playListRepository)
+		updatePlayListUsecase := usecase.NewUpdatePlayList(playListRepository, movieRepository)
 		updatePlayListHandler := handler.NewUpdatePlayListHandler(updatePlayListUsecase)
 		auth.PUT("/play-lists", updatePlayListHandler.Update)
 

--- a/go/src/MyPIPE/usecase/UpdatePlayList.go
+++ b/go/src/MyPIPE/usecase/UpdatePlayList.go
@@ -12,10 +12,14 @@ type IUpdatePlayList interface {
 
 type UpdatePlayList struct {
 	PlayListRepository repository.PlayListRepository
+	MovieRepository    repository.MovieRepository
 }
 
-func NewUpdatePlayList(playListRepository repository.PlayListRepository) *UpdatePlayList {
-	return &UpdatePlayList{PlayListRepository: playListRepository}
+func NewUpdatePlayList(playListRepository repository.PlayListRepository, movieRepository repository.MovieRepository) *UpdatePlayList {
+	return &UpdatePlayList{
+		PlayListRepository: playListRepository,
+		MovieRepository:    movieRepository,
+	}
 }
 
 func (u UpdatePlayList) Update(updatePlayListDTO *UpdatePlayListDTO) error {
@@ -27,6 +31,14 @@ func (u UpdatePlayList) Update(updatePlayListDTO *UpdatePlayListDTO) error {
 		return errors.New("No Such PlayList.")
 	}
 
+	thumbnailMovie, thumbnailMovieErr := u.MovieRepository.FindById(updatePlayListDTO.ThumbnanilMovieID)
+	if thumbnailMovieErr != nil {
+		return thumbnailMovieErr
+	}
+	if thumbnailMovie == nil {
+		return errors.New("No Such Movie.")
+	}
+
 	changePlayListNameErr := playList.ChangeName(updatePlayListDTO.PlayListName)
 	if changePlayListNameErr != nil {
 		return changePlayListNameErr
@@ -35,6 +47,11 @@ func (u UpdatePlayList) Update(updatePlayListDTO *UpdatePlayListDTO) error {
 	changePlayListDescriptionErr := playList.ChangeDescription(updatePlayListDTO.PlayListDescription)
 	if changePlayListDescriptionErr != nil {
 		return changePlayListDescriptionErr
+	}
+
+	changeThumbnailMovieErr := playList.ChangeThumbnailMovie(updatePlayListDTO.ThumbnanilMovieID)
+	if changeThumbnailMovieErr != nil {
+		return changeThumbnailMovieErr
 	}
 
 	savePlayListErr := u.PlayListRepository.Save(playList)
@@ -50,13 +67,15 @@ type UpdatePlayListDTO struct {
 	PlayListID          model.PlayListID
 	PlayListName        model.PlayListName
 	PlayListDescription model.PlayListDescription
+	ThumbnanilMovieID   model.MovieID
 }
 
-func NewUpdatePlayListDTO(userId model.UserID, playListId model.PlayListID, playListName model.PlayListName, playListDescription model.PlayListDescription) *UpdatePlayListDTO {
+func NewUpdatePlayListDTO(userId model.UserID, playListId model.PlayListID, playListName model.PlayListName, playListDescription model.PlayListDescription, thumbnailMovieId model.MovieID) *UpdatePlayListDTO {
 	return &UpdatePlayListDTO{
 		UserID:              userId,
 		PlayListID:          playListId,
 		PlayListName:        playListName,
 		PlayListDescription: playListDescription,
+		ThumbnanilMovieID:   thumbnailMovieId,
 	}
 }


### PR DESCRIPTION
・play_listsテーブルにサムネイル用の動画のidカラムを設定
go/src/MyPIPE/Migrations/000025_add_thumbnail_movie_id_column_to_play_lists_table.up.sql 
go/src/MyPIPE/Migrations/000025_add_thumbnail_movie_id_column_to_play_lists_table.down.sql 
・PlayListモデルにサムネイル用の動画のIDを入れるプロパティを追加
go/src/MyPIPE/domain/model/PlayList.go 
・再生リストのサムネイルを設定する処理をhandlerとusecaseに追加
 go/src/MyPIPE/handler/UpdatePlayList.go
go/src/MyPIPE/usecase/UpdatePlayList.go