### PR TITLE
パスワードリセットトークン生成用のAPIを実装

### DIFF
--- a/go/src/MyPIPE/Migrations/000028_add_remember_token_and_at_column_to_users_table.down.sql
+++ b/go/src/MyPIPE/Migrations/000028_add_remember_token_and_at_column_to_users_table.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users DROP COLUMN password_remember_token;
+ALTER TABLE users DROP COLUMN password_remember_token_at;

--- a/go/src/MyPIPE/Migrations/000028_add_remember_token_and_at_column_to_users_table.up.sql
+++ b/go/src/MyPIPE/Migrations/000028_add_remember_token_and_at_column_to_users_table.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users ADD COLUMN password_remember_token LONGTEXT NULL AFTER token;
+ALTER TABLE users ADD COLUMN password_remember_token_at INTEGER UNSIGNED NULL AFTER password_remember_token;

--- a/go/src/MyPIPE/domain/model/User.go
+++ b/go/src/MyPIPE/domain/model/User.go
@@ -102,6 +102,10 @@ func NewUserProfileImage(fileHeader multipart.FileHeader, file multipart.File) (
 	}, nil
 }
 
+type UserPasswordRememberToken string
+
+type UserPasswordRememberTokenAt uint64
+
 type User struct {
 	ID               UserID   `json:"id" gorm:"primaryKey"`
 	Name             UserName `json:"name"`
@@ -110,6 +114,8 @@ type User struct {
 	Birthday         time.Time `json:"birthday"`
 	ProfileImageName string    `json:"profile_image_name"`
 	Token            UserToken `json:"token"`
+	PasswordRememberToken	UserPasswordRememberToken
+	PasswordRememberTokenAt UserPasswordRememberTokenAt
 	CreatedAt        time.Time `json:"created_at"`
 	UpdatedAt        time.Time `json:"updated_at"`
 }
@@ -222,4 +228,10 @@ func (u *User) Register(name UserName, password UserPassword, birthday time.Time
 	u.Password = password
 	u.Birthday = birthday
 	return nil
+}
+
+func (u *User) SetPasswordRememberToken()(UserPasswordRememberToken,error){
+	u.PasswordRememberToken = UserPasswordRememberToken(uuid.New().String())
+	u.PasswordRememberTokenAt = UserPasswordRememberTokenAt(time.Now().Unix())
+	return u.PasswordRememberToken,nil
 }

--- a/go/src/MyPIPE/domain/repository/ResetPasswordEmail.go
+++ b/go/src/MyPIPE/domain/repository/ResetPasswordEmail.go
@@ -1,0 +1,7 @@
+package repository
+
+import "MyPIPE/domain/model"
+
+type ResetPasswordEmail interface {
+	Send(email model.UserEmail,token model.UserPasswordRememberToken)error
+}

--- a/go/src/MyPIPE/handler/ResetPassword.go
+++ b/go/src/MyPIPE/handler/ResetPassword.go
@@ -1,0 +1,53 @@
+package handler
+
+import (
+	"MyPIPE/domain/model"
+	"MyPIPE/usecase"
+	"github.com/gin-gonic/gin"
+	"net/http"
+)
+
+type SetPasswordRememberToken struct{
+	SetPasswordRememberTokenUsecase usecase.ISetPasswordRememberToken
+}
+
+
+func NewSetPasswordRememberToken(setPasswordRememberTokenUsecase usecase.ISetPasswordRememberToken)*SetPasswordRememberToken{
+	return &SetPasswordRememberToken{
+		SetPasswordRememberTokenUsecase: setPasswordRememberTokenUsecase,
+	}
+}
+
+func (r SetPasswordRememberToken)SetPasswordRememberToken(c *gin.Context){
+	var resetPasswordJson ResetPasswordJson
+	c.Bind(&resetPasswordJson)
+
+	userEmail,userEmailErr := model.NewUserEmail(resetPasswordJson.Email)
+	if userEmailErr != nil{
+		c.JSON(http.StatusBadRequest, gin.H{
+			"result":   "Validation Error.",
+			"messages": userEmailErr.Error(),
+		})
+		c.Abort()
+		return
+	}
+
+	setPasswordRememberTokenDTO := usecase.NewSetPasswordRememberTokenDTO(userEmail)
+	setPasswordRememberTokenErr := r.SetPasswordRememberTokenUsecase.SetPasswordRememberToken(setPasswordRememberTokenDTO)
+	if setPasswordRememberTokenErr != nil{
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"result":   "Reset Password Error.",
+			"messages": setPasswordRememberTokenErr.Error(),
+		})
+		c.Abort()
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "Success!",
+	})
+}
+
+type ResetPasswordJson struct{
+	Email string	`json:"email"`
+}

--- a/go/src/MyPIPE/infra/ResetPasswordEmailRepository.go
+++ b/go/src/MyPIPE/infra/ResetPasswordEmailRepository.go
@@ -7,19 +7,19 @@ import (
 	"github.com/aws/aws-sdk-go/service/ses"
 )
 
-type TemporaryRegisterMailRepository struct{}
+type ResetPasswordEmail struct{}
 
-func NewTemporaryRegisterMailRepository() *TemporaryRegisterMailRepository {
-	return &TemporaryRegisterMailRepository{}
+func NewResetPasswordEmail()*ResetPasswordEmail{
+	return &ResetPasswordEmail{}
 }
 
-func (t TemporaryRegisterMailRepository) Send(mail *model.TemporaryRegisterMail) error {
+func (r ResetPasswordEmail)Send(email model.UserEmail,token model.UserPasswordRememberToken)error{
 	sess := session.Must(session.NewSession())
 	svc := ses.New(sess)
 	input := &ses.SendEmailInput{
 		Destination: &ses.Destination{
 			ToAddresses: []*string{
-				aws.String(string(mail.To)),
+				aws.String(string(email)),
 			},
 		},
 		Message: &ses.Message{
@@ -27,16 +27,16 @@ func (t TemporaryRegisterMailRepository) Send(mail *model.TemporaryRegisterMail)
 				Text: &ses.Content{
 					Charset: aws.String("UTF-8"),
 					Data: aws.String(
-						"現在、仮登録の状態です。以下のURLにアクセスして情報を入力し、本登録を完了してください\nhttps:" +
-							"//www.frommymovies/register?token=" + string(mail.Token)),
+						"パスワードを再発行します。以下のURLにアクセスして新しいパスワードを設定してください。\nhttps:" +
+							"//www.frommymovies.com/reset?token=" + string(token)),
 				},
 			},
 			Subject: &ses.Content{
 				Charset: aws.String("UTF-8"),
-				Data:    aws.String("MyMovies仮登録のご案内"),
+				Data:    aws.String("MyMoviesパスワード再設定のご案内"),
 			},
 		},
-		Source: aws.String(string(mail.From)),
+		Source: aws.String("reset@mail.frommymovies.com"),
 	}
 
 	_, sendMailErr := svc.SendEmail(input)

--- a/go/src/MyPIPE/main.go
+++ b/go/src/MyPIPE/main.go
@@ -97,6 +97,11 @@ func main() {
 
 	api := router.Group("/api/v1")
 
+	resetPasswordEmailRepository := infra.NewResetPasswordEmail()
+	setPasswordRememberTokenUsecase := usecase.NewSetPasswordRememberToken(userRepository,resetPasswordEmailRepository)
+	setPasswordRememberTokenHandler := handler.NewSetPasswordRememberToken(setPasswordRememberTokenUsecase)
+	api.POST("/remember", setPasswordRememberTokenHandler.SetPasswordRememberToken)
+
 	commentQueryService := queryService_infra.NewCommentQueryService()
 	getCommentsUsecase := usecase.NewGetMovieAndComments(commentQueryService)
 	getMovieAndCommentsHandler := handler.NewGetMovieAndComments(commentQueryService, getCommentsUsecase)

--- a/go/src/MyPIPE/usecase/ResetPassword.go
+++ b/go/src/MyPIPE/usecase/ResetPassword.go
@@ -1,0 +1,60 @@
+package usecase
+
+import (
+	"MyPIPE/domain/model"
+	"MyPIPE/domain/repository"
+	"errors"
+)
+
+type ISetPasswordRememberToken interface {
+	SetPasswordRememberToken(setPasswordRememberTokenDTO *SetPasswordRememberTokenDTO)error
+}
+
+type SetPasswordRememberToken struct{
+	UserRepository repository.UserRepository
+	ResetPasswordEmailRepository repository.ResetPasswordEmail
+}
+
+func NewSetPasswordRememberToken(userRepository repository.UserRepository, resetPasswordEmailRepository repository.ResetPasswordEmail)*SetPasswordRememberToken{
+	return &SetPasswordRememberToken{
+		UserRepository: userRepository,
+		ResetPasswordEmailRepository: resetPasswordEmailRepository,
+	}
+}
+
+func (r SetPasswordRememberToken)SetPasswordRememberToken(setPasswordRememberTokenDTO *SetPasswordRememberTokenDTO)error{
+	user,findUserErr := r.UserRepository.FindByEmail(setPasswordRememberTokenDTO.Email)
+	if findUserErr != nil{
+		return findUserErr
+	}
+	if user == nil{
+		return errors.New("No Such User.")
+	}
+
+	rememberPasswordToken,rememberPasswordTokenErr := user.SetPasswordRememberToken()
+	if rememberPasswordTokenErr != nil{
+		return rememberPasswordTokenErr
+	}
+
+	setUserErr := r.UserRepository.UpdateUser(user)
+	if setUserErr != nil{
+		return setUserErr
+	}
+
+	sendMailErr := r.ResetPasswordEmailRepository.Send(user.Email,rememberPasswordToken)
+	if sendMailErr != nil{
+		return sendMailErr
+	}
+
+	return nil
+}
+
+type SetPasswordRememberTokenDTO struct{
+	Email	model.UserEmail
+}
+
+func NewSetPasswordRememberTokenDTO(email model.UserEmail)*SetPasswordRememberTokenDTO{
+	return &SetPasswordRememberTokenDTO{
+		Email: email,
+	}
+}


### PR DESCRIPTION
・ハンドラー
go/src/MyPIPE/handler/ResetPassword.go
・ユースケース
go/src/MyPIPE/usecase/ResetPassword.go
・トークンと生成時間を保存するカラムをusersテーブルに追加
go/src/MyPIPE/Migrations/000028_add_remember_token_and_at_column_to_users_table.up.sql
go/src/MyPIPE/Migrations/000028_add_remember_token_and_at_column_to_users_table.down.sql
・トークンと生成時間を設定するメソッドをUserモデルに追加
go/src/MyPIPE/domain/model/User.go